### PR TITLE
Smaller header images and cleanup

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -189,7 +171,12 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_plain.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
+    <a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_plain.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_plain.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>
 				
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">

--- a/competitions/index.html
+++ b/competitions/index.html
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -192,10 +174,8 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 	<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
         <picture class="header-image">
             <source srcset="/images/header_tenors.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
-            nope
-            <!--img src="/wp-content/uploads/2015/01/header_tenors.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band"-->
-            <!--<img src="/images/header_tenors.webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />-->
-        </picture>        
+            <img src="/wp-content/uploads/2015/01/header_tenors.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
     </a>
 				
 	<nav id="access" class="clearfix">

--- a/contact/index.html
+++ b/contact/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -189,8 +171,14 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_bus.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+	<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_bus.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_bus.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>
+
+    
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>

--- a/faq/index.html
+++ b/faq/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -189,8 +171,14 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_wayne.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+	<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_wayne.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_wayne.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>
+
+    
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>

--- a/hire/index.html
+++ b/hire/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -189,8 +171,13 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_tenors.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+    <a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_tenors.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_tenors.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>
+
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>

--- a/history/index.html
+++ b/history/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -22,26 +22,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -191,8 +173,13 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_calvin.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+	<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_calvin.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_calvin.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>
+    
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -189,8 +171,13 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_jeff.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+    <a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_tenors.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_tenors.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>				
+            
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom current-menu-item current_page_item menu-item-11"><a href="/" aria-current="page">Home</a></li>

--- a/join/index.html
+++ b/join/index.html
@@ -2,11 +2,11 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
-<title>Join - Cincinnati Caledonian Pipes &amp; Drums Band</title>
+    <title>Join - Cincinnati Caledonian Pipes &amp; Drums Band</title>
 
 <!-- This site is optimized with the Yoast SEO plugin v12.7.1 - https://yoast.com/wordpress/plugins/seo/ -->
 <meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1">
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -190,8 +172,12 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_jeff.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+	<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_jeff.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_jeff.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>				
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>

--- a/learning-to-play-the-bagpipes/index.html
+++ b/learning-to-play-the-bagpipes/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -22,26 +22,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -191,8 +173,12 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_paul.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+	<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_paul.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_paul.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>				
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>

--- a/lessons/index.html
+++ b/lessons/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -22,26 +22,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -191,8 +173,13 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_paul.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+    <a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_paul.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_paul.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>
+            
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>

--- a/mission/index.html
+++ b/mission/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 
-		<meta charset="UTF-8">
+    <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="/xmlrpc.php">	
@@ -21,26 +21,8 @@
 <!-- / Yoast SEO plugin. -->
 
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
 <link rel="alternate" type="application/rss+xml" title="Cincinnati Caledonian Pipes &amp; Drums Band &raquo; Feed" href="/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/cincypipesanddrums.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.4.9"}};
-			/*! This file is auto-generated */
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}</style>
-	<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
+<link rel="stylesheet" id="wp-block-library-css" href="/wp-includes/css/dist/block-library/style.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-font-awesome-css" href="/wp-content/plugins/download-manager/assets/fontawesome/css/all.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-bootstrap-css" href="/wp-content/plugins/download-manager/assets/bootstrap/css/bootstrap.min.css?ver=5.4.9" type="text/css" media="all">
 <link rel="stylesheet" id="wpdm-front-css" href="/wp-content/plugins/download-manager/assets/css/front.css?ver=5.4.9" type="text/css" media="all">
@@ -190,8 +172,14 @@ var wpdm_asset = {"spinner":"<i class=\"fas fa-sun fa-spin\"><\/i>"};
 <!-- .hgroup-wrap -->
 	</div>
 <!-- .container -->	
-					<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band"><img src="/wp-content/uploads/2015/01/header_drums.png" class="header-image" width="1038" height="150" alt="Cincinnati Caledonian Pipes &amp; Drums Band"></a>
-				
+	<a href="/" title="Cincinnati Caledonian Pipes &amp; Drums Band">
+        <picture class="header-image">
+            <source srcset="/images/header_drums.webp" type="image/webp" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+            <img src="/wp-content/uploads/2015/01/header_drums.png" alt="Cincinnati Caledonian Pipes &amp; Drums Band" />
+        </picture>
+    </a>				
+
+    
 	<nav id="access" class="clearfix">
 					<div class="container clearfix"><ul class="root">
 <li id="menu-item-11" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-11"><a href="/">Home</a></li>


### PR DESCRIPTION
Changes of note:
* Updated all views to use the webp versions of header images if supported, with a fallback to the much larger png file size.
* Cleaned up some unused references