### PR TITLE
disabling Cincy indoor registration

### DIFF
--- a/comp/index.html
+++ b/comp/index.html
@@ -130,8 +130,8 @@
                     takes place in the evening after this event as well, just a few minutes' drive away! -->
                 </p>
                 <p>
-                  <a id=register href="/comp/reg/">Register</a>
-                    <!--Registration for the competition is now closed (workshop registrations still welcome - please contact Andy Douglas at <a href="mailto:webmaster@cincypipesanddrums.org">webmaster@cincypipesanddrums.org</a>).  <a href="https://docs.google.com/spreadsheets/d/1DvT_z1Av6jpTGzOm0-JumN3PvXBLblIGOwLlwkMtdSA/edit?usp=sharing" target="_blank">Click here</a> to see the current competition schedule.-->
+                  <!--<a id=register href="/comp/reg/">Register</a>-->
+                  Registration for the competition is now closed (workshop registrations still welcome - please contact Andy Douglas at <a href="mailto:webmaster@cincypipesanddrums.org">webmaster@cincypipesanddrums.org</a>).  <!--a href="https://docs.google.com/spreadsheets/d/1DvT_z1Av6jpTGzOm0-JumN3PvXBLblIGOwLlwkMtdSA/edit?usp=sharing" target="_blank">Click here</a> to see the current competition schedule.-->
                 </p>
 
                 <h3>Solo Competition Information (time TBA)</h3>
@@ -264,9 +264,9 @@
                     </tbody>
                 </table>
 
-                <!--<p>
+                <p>
                     Registration for the competition is now closed (workshop registrations are still welcome - please contact Andy Douglas at <a href="mailto:webmaster@cincypipesanddrums.org">webmaster@cincypipesanddrums.org</a>).
-                </p> -->
+                </p>
                 
                 <p>
                     <b>Event Date: </b>
@@ -301,17 +301,17 @@
                     <tr>
                       <td>Light music</td>
                       <td>Clark Abercrombie</td>
-                      <td>Session 1: TBA<br />Session 2: TBA</td>
+                      <td>Session 1: Tips on playing 6/8 marches<br />Session 2: Using a metronome and balancing rudiments in tempo</td>
                     </tr>
                     <tr>
                       <td>Light music</td>
                       <td>Barry Conway</td>
-                      <td>Session 1: TBA<br />Session 2: TBA</td>
+                      <td>Session 1: Competition Prep<br />Session 2: Expression in Marches and strathspeys</td>
                     </tr>
                     <tr>
                       <td>Light Music</td>
                       <td>Calum MacDonald</td>
-                      <td>Session 1: TBA<br />Session 2: TBA</td>
+                      <td>Session 1: Listening for Improvement; help yourself and others improve<br />Session 2: Tune selections for solos and bands including piob</td>
                     </tr>
                     <tr>
                       <td>Snare</td>

--- a/comp/reg/index.html
+++ b/comp/reg/index.html
@@ -17,7 +17,9 @@
           
           <h1>Cincinnati Indoor Solo Contest and Workshop Registration</h1>
           <hr />
-          <div id="wizard-container" ng-controller="WizardController as vm">
+          <h2>Registration for the 2025 competition is now closed</h2>
+          <div>Contact Andy Douglas at <a href="mailto:webmaster@cincypipesanddrums.org">webmaster@cincypipesanddrums.org</a> if you would like to register for the workshop</div>
+          <div id="wizard-container" ng-controller="xWizardControllerx as vm">
             
             <div id="wizard-step-container">
             </div>


### PR DESCRIPTION
This PR mades the following changes:
* On the /comp page, replaces the registration link with a link to the webmaster email address to stop registrations
* On the /comp/reg page, disables the registration program